### PR TITLE
Fixes Autotransfer Config

### DIFF
--- a/modular_R505/code/modules_n_adds/transfer/autotransfer_config.dm
+++ b/modular_R505/code/modules_n_adds/transfer/autotransfer_config.dm
@@ -1,12 +1,12 @@
 /// Length of time before the first autotransfer vote is called (deciseconds, default 2 hours)
 /// Set to 0 to disable the subsystem altogether.
 /datum/config_entry/number/vote_autotransfer_initial
-	config_entry_value = 3600 //72000
+	config_entry_value = 72000
 	min_val = 0
 
 ///length of time to wait before subsequent autotransfer votes (deciseconds, default 30 minutes)
 /datum/config_entry/number/vote_autotransfer_interval
-	config_entry_value = 3600
+	config_entry_value = 36000
 	min_val = 0
 
 /// maximum extensions until the round autoends.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sets the config for the auto-transfer vote to reasonable values. 

## Why It's Good For The Game

No one wants an auto-transfer vote every 6 minutes.

## Changelog
:cl:
fix: Auto-transfer timer set to reasonable values instead of testing values.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
