### PR TITLE
URGENT FIX

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -310,6 +310,7 @@
 	slot = "brain"
 	zone = "chest"
 	status = ORGAN_ROBOTIC
+	decay_factor = 0
 	//remove_on_qdel = FALSE
 	var/obj/item/mmi/stored_mmi
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Positronic brain holder organ decays while host is alive, this prevents it from decaying. 

## Why It's Good For The Game

Synths won't die of nonsensical brain damage.

## Changelog
:cl:
fix: positronic brain holders don't decay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
