### PR TITLE
Posibrain Surgery

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -78,9 +78,10 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define isdullahan(A) (is_species(A, /datum/species/dullahan))
 #define ismonkey(A) (is_species(A, /datum/species/monkey))
 
-#define issynthliz(A) (is_species(A,/datum/species/synthliz))
+#define issynthliz(A) (is_species(A,/datum/species/robotic/synthliz))
+#define issynthetic(A) (is_species(A,/datum/species/robotic)) //R505 Edit
 #define isvox(A) (is_species(A,/datum/species/vox))
-#define isipc(A) (is_species(A,/datum/species/ipc))
+#define isipc(A) (is_species(A,/datum/species/robotic/ipc))
 #define ismammal(A) (is_species(A,/datum/species/mammal))
 #define ispodweak(A) (is_species(A,/datum/species/pod/podweak))
 #define isxenohybrid(A) (is_species(A,/datum/species/xeno))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Positronic brains can now be removed and replaced for synthetic species (synthliz, IPC, etc.).

## Why It's Good For The Game

Will allow the reconstruction of a synthetic (NYI), whereas previously a posibrain could only be placed in a borg or ai core.

## Changelog
:cl:
add: Adds the ability to add positronic brains to and remove them from synthetics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
