### PR TITLE
Sound Changes + Fix

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -161,10 +161,10 @@
 	switch(animation)
 		if("opening")
 			flick("opening", src)
-			playsound(src, 'sound/machines/blastdoor.ogg', 30, TRUE)
+			playsound(src, 'sound/machines/blastdoor.ogg', 30, FALSE)
 		if("closing")
 			flick("closing", src)
-			playsound(src, 'sound/machines/blastdoor.ogg', 30, TRUE)
+			playsound(src, 'sound/machines/blastdoor.ogg', 30, FALSE)
 
 /obj/machinery/door/poddoor/update_icon_state()
 	. = ..()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -161,7 +161,7 @@
 	if(!operating) //in case of emag
 		operating = TRUE
 	do_animate("opening")
-	playsound(src, 'modular_R505/sound/doors/windowdoor.ogg', 100, TRUE)
+	playsound(src, 'modular_R505/sound/doors/windowdoor.ogg', 100, FALSE) //R505 Edit
 	icon_state ="[base_state]open"
 	sleep(10)
 	set_density(FALSE)
@@ -183,7 +183,7 @@
 			return 0
 	operating = TRUE
 	do_animate("closing")
-	playsound(src, 'modular_R505/sound/doors/windowdoor.ogg', 100, TRUE)
+	playsound(src, 'modular_R505/sound/doors/windowdoor.ogg', 100, FALSE) //R505 Edit
 	icon_state = base_state
 
 	set_density(TRUE)

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -126,9 +126,9 @@
 		var/obj/item/mmi/P = tool
 		if(!istype(P))
 			return -1
-		//if(!target_mmi.brainmob || !target_mmi.brainmob.client)
-			//to_chat(user, "<span class='notice'>[tool] has no life in it, this would be pointless!</span>")
-			//return -1
+		if(!target_mmi.brainmob || !target_mmi.brainmob.client)
+			to_chat(user, "<span class='notice'>[tool] has no life in it, this would be pointless!</span>")
+			return -1
 		var/obj/item/organ/meatslab = tool
 		if(!meatslab.useable)
 			to_chat(user, "<span class='warning'>[tool] seems to have been chewed on, you can't use this!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes varying sound pitch from windoors and blast doors.
Re-enables a check that was commented out in the posibrain surgery pr - was disabled for testing purposes and forgot to re-enable

## Changelog
:cl:
fix: Sound variation removed from windoors + blast doors
fix: Can no longer put a "dead" posibrain in a synth.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
