### PR TITLE
ChirpFix

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -871,7 +871,6 @@
 	key_third_person = "peeps"
 	message = "peeps like a bird!"
 	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
 	sound = 'sound/voice/peep_once.ogg'
 
 /datum/emote/living/peep2
@@ -879,10 +878,9 @@
 	key_third_person = "peeps twice"
 	message = "peeps twice like a bird!"
 	emote_type = EMOTE_AUDIBLE
-	vary = TRUE
 	sound = 'sound/voice/peep.ogg'
 
-	//R505 Edit. the first chirp is from a unused sound found in the code that had no links to anything. else so it was repurposed.
+	//R505 Edit. the first chirp is from a unused sound found in the code that had no links to anything. else so it was repurposed. I removed the vary = true flag so my chirp 2 does not sound uncanny -Summer :cheese:
  
 /datum/emote/living/chirp
     key = "chirp"


### PR DESCRIPTION
Removes Vary=True on both chirps

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes the Vary=True lines on both, Chirp and Chirp2

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it helps with roleplay as having the chirp emotes change in pitch from +40 to -50 makes it sound uncanny,

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
