### PR TITLE
Combat Wrench Taken Behind The Shed

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -129,7 +129,7 @@
 
 /obj/item/storage/belt/utility/syndicate/PopulateContents()
 	new /obj/item/screwdriver/nuke(src)
-	new /obj/item/wrench/combat(src)
+	new /obj/item/wrench/syndie(src) //R505 Edit - Syndie Wrench
 	new /obj/item/weldingtool/largetank(src)
 	new /obj/item/crowbar(src)
 	new /obj/item/wirecutters(src)

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -164,7 +164,7 @@
 
 /obj/item/storage/toolbox/syndicate/PopulateContents()
 	new /obj/item/screwdriver/nuke(src)
-	new /obj/item/wrench(src)
+	new /obj/item/wrench/syndie(src) //R505 Edit - Give em the syndie wrench
 	new /obj/item/weldingtool/largetank(src)
 	new /obj/item/crowbar/red(src)
 	new /obj/item/wirecutters(src, "red")

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -78,16 +78,23 @@
 	icon_state = "wrench_cyborg"
 	toolspeed = 0.5
 
+//R505 Edit - Begin
+
+/obj/item/wrench/syndie
+	name = "syndicate wrench"
+	desc = "A blood-red pipewrench with a black stripe. Feels weighty."
+	icon_state = "wrench_syndie"
+	force = 6
+	throwforce = 8
+
+/*
 /obj/item/wrench/combat
 	name = "combat wrench"
-	desc = "It's like a normal wrench but edgier. Can be found on the battlefield."
+	desc = "It's like a normal wrench but edgier."
 	icon_state = "wrench_combat"
-	inhand_icon_state = "wrench_combat"
-	attack_verb_continuous = list("devastates", "brutalizes", "commits a war crime against", "obliterates", "humiliates")
-	attack_verb_simple = list("devastate", "brutalize", "commit a war crime against", "obliterate", "humiliate")
-	tool_behaviour = null
-	toolspeed = null
-	var/on = FALSE
+	force = 6
+	throwforce = 8
+
 
 /obj/item/wrench/combat/ComponentInitialize()
 	. = ..()
@@ -122,3 +129,4 @@
 		icon_state = "[initial(icon_state)]"
 		inhand_icon_state = "[initial(inhand_icon_state)]"
 	return ..()
+*/ //R505 Edit - End


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the combat wrench, which looked like ass, with a more stylish syndie wrench.

## Why It's Good For The Game

Consistency in tool sprites.

## Changelog
:cl:
add: Syndie Wrench.
del: Combat Wrench.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
