### PR TITLE
Fixes felinids being unable to use technology or remove items/clothing from people

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -10,10 +10,11 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/felinid
 	inherent_traits = list(
+		TRAIT_ADVANCEDTOOLUSER,
+		TRAIT_CAN_STRIP,
 		TRAIT_FREERUNNING,
 		TRAIT_SKITTISH,
-		TRAIT_LIGHT_STEP
-		
+		TRAIT_LIGHT_STEP	
 	)
 
 	mutanteyes = /obj/item/organ/eyes/night_vision/feline


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds `TRAIT_ADVANCEDTOOLUSER` and `TRAIT_CAN_STRIP` to felinid.dm, allowing them to once again do the basic actions literally all roundstart species are capable of, if not all player species.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Undoes a major problem caused by the hellspawn known as #52
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Felinids can once again use technology and steal from people. Joy!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
